### PR TITLE
Swap LWR problems to 3D lattices

### DIFF
--- a/models/lwr/17x17_uo2_assembly/rodded/make_openmc_model.py
+++ b/models/lwr/17x17_uo2_assembly/rodded/make_openmc_model.py
@@ -31,19 +31,20 @@ args = ap.parse_args()
 #--------------------------------------------------------------------------------------------------------------------------#
 # Geometry definitions.
 assembly_bb.boundary_type = 'reflective'
-core_z_planes = [ openmc.ZPlane(z0=z) for z in np.linspace(0.0, geom.core_height, args.n_axial + 1) ]
-core_z_planes[0].boundary_type = 'reflective'
+fuel_center = openmc.ZPlane(z0 = 0.0, boundary_type = 'reflective')
+fuel_top = openmc.ZPlane(z0 = geom.core_height)
 
-all_cells = []
-for layer_idx, planes in enumerate(zip(core_z_planes[:-1], core_z_planes[1:])):
-  all_cells.append(openmc.Cell(name = f'UO2 Assembly Cell {layer_idx}', region = -assembly_bb & +planes[0] & -planes[1], fill = asmb['UO2_ROD']))
+asmb['UO2_ROD'].fill.pitch = (geom.pitch, geom.pitch, geom.core_height / args.n_axial)
+asmb['UO2_ROD'].fill.lower_left = (-pins_per_axis * geom.pitch / 2.0, -pins_per_axis * geom.pitch / 2.0, 0.0)
+asmb['UO2_ROD'].fill.universes = [ asmb['UO2_ROD'].fill.universes for i in range(args.n_axial) ]
+asmb['UO2_ROD'].region = asmb['UO2_ROD'].region & +fuel_center & -fuel_top
 
 refl_top = openmc.ZPlane(z0 = geom.core_height + geom.reflector_t, boundary_type = 'vacuum')
-all_cells.append(openmc.Cell(name='Axial Reflector Cell', fill = asmb['REF_ROD'], region=-assembly_bb & -refl_top & +core_z_planes[-1]))
+asmb['REF_ROD'].region = asmb['REF'].region & -refl_top & +fuel_top
 
 #--------------------------------------------------------------------------------------------------------------------------#
 # Setup the model.
-c5g7_model = openmc.Model(geometry = openmc.Geometry(openmc.Universe(cells = all_cells)), materials = openmc.Materials([mats['UO2'], mats['H2O'], mats['FISS'], mats['ZR_C'], mats['AL_C'], mats['BC4']]))
+c5g7_model = openmc.Model(geometry = openmc.Geometry(openmc.Universe(cells = [asmb['UO2_ROD'], asmb['REF_ROD']])), materials = openmc.Materials([mats['UO2'], mats['H2O'], mats['FISS'], mats['ZR_C'], mats['AL_C'], mats['BC4']]))
 
 ## The simulation settings.
 c5g7_model.settings.source = [openmc.IndependentSource(space = openmc.stats.Box(lower_left = (-pins_per_axis * geom.pitch / 2.0, -pins_per_axis * geom.pitch / 2.0, 0.0),

--- a/models/lwr/3x3_lattice/make_openmc_model.py
+++ b/models/lwr/3x3_lattice/make_openmc_model.py
@@ -30,31 +30,28 @@ args = ap.parse_args()
 #--------------------------------------------------------------------------------------------------------------------------#
 # Geometry definitions.
 pins_per_axis = 3.0
-core_z_planes = [ openmc.ZPlane(z0=z) for z in np.linspace(0.0, geom.core_height, args.n_axial + 1) ]
-core_z_planes[0].boundary_type = 'reflective'
+fuel_center = openmc.ZPlane(z0 = 0.0, boundary_type = 'reflective')
+fuel_top = openmc.ZPlane(z0 = geom.core_height)
+assembly_bb = openmc.model.RectangularPrism(width = pins_per_axis * geom.pitch, height = pins_per_axis * geom.pitch, origin = (0.0, 0.0), boundary_type = 'reflective')
 
-assembly = openmc.RectLattice(name='Fuel Assembly')
-assembly.pitch = (geom.pitch, geom.pitch)
-assembly.lower_left = (-pins_per_axis * geom.pitch / 2.0, -pins_per_axis * geom.pitch / 2.0)
-assembly.universes = [
+core_assembly = openmc.RectLattice(name='Fuel Assembly')
+core_assembly.pitch = (geom.pitch, geom.pitch, geom.core_height / args.n_axial)
+core_assembly.lower_left = (-pins_per_axis * geom.pitch / 2.0, -pins_per_axis * geom.pitch / 2.0, 0.0)
+core_assembly.universes = [ [
   [pins['UO2'], pins['UO2'], pins['UO2']],
   [pins['UO2'], pins['UO2'], pins['UO2']],
   [pins['UO2'], pins['UO2'], pins['UO2']]
-]
-assembly_bb = openmc.model.RectangularPrism(width = pins_per_axis * geom.pitch, height = pins_per_axis * geom.pitch, origin = (0.0, 0.0), boundary_type = 'reflective')
-
-all_cells = []
-for layer_idx, planes in enumerate(zip(core_z_planes[:-1], core_z_planes[1:])):
-  all_cells.append(openmc.Cell(name = f'UO2 Assembly Cell {layer_idx}', region = -assembly_bb & +planes[0] & -planes[1], fill = assembly))
+] for i in range(args.n_axial) ]
+core_assembly_cell = openmc.Cell(name = 'UO2 Pincell Lattice Cell', region = -assembly_bb & +fuel_center & -fuel_top, fill = core_assembly)
 
 ## Add the top axial water reflector.
 refl_top = openmc.ZPlane(z0 = geom.core_height + geom.reflector_t, boundary_type = 'vacuum')
-all_cells.append(openmc.Cell(name='Axial Reflector Cell', fill = mats['H2O'], region=-assembly_bb & -refl_top & +core_z_planes[-1]))
+refl_cell = openmc.Cell(name='Axial Reflector Cell', fill = mats['H2O'], region=-assembly_bb & -refl_top & +fuel_top)
 #--------------------------------------------------------------------------------------------------------------------------#
 
 #--------------------------------------------------------------------------------------------------------------------------#
 # Setup the model.
-mult_pincell_model = openmc.Model(geometry = openmc.Geometry(openmc.Universe(cells = all_cells)), materials = openmc.Materials([mats['UO2'], mats['H2O'], mats['ZR_C']]))
+mult_pincell_model = openmc.Model(geometry = openmc.Geometry(openmc.Universe(cells = [core_assembly_cell, refl_cell])), materials = openmc.Materials([mats['UO2'], mats['H2O'], mats['ZR_C']]))
 
 ## The simulation settings.
 mult_pincell_model.settings.source = [openmc.IndependentSource(space = openmc.stats.Box(lower_left = (-pins_per_axis * geom.pitch / 2.0, -pins_per_axis * geom.pitch / 2.0, 0.0),

--- a/models/lwr/3x3_lattice/mesh.i
+++ b/models/lwr/3x3_lattice/mesh.i
@@ -23,9 +23,6 @@
     heights = '${fparse core_height}'
     num_layers = '${AXIAL_DIVISIONS}'
     direction = '0.0 0.0 1.0'
-
-    bottom_boundary = '10001'
-    top_boundary = '10000'
   []
   [To_Origin]
     type = TransformGenerator

--- a/models/lwr/multi_assembly/rodded/make_openmc_model.py
+++ b/models/lwr/multi_assembly/rodded/make_openmc_model.py
@@ -20,7 +20,7 @@ from argparse import ArgumentParser
 import openmc
 import openmc_common as geom
 from openmc_materials import MATERIALS as mats
-from openmc_assemblies import ASSEMBLIES as asmb
+from openmc_assemblies import ASSEMBLY_UNIVERSES as asmb
 from openmc_assemblies import pins_per_axis
 
 ap = ArgumentParser()
@@ -30,7 +30,10 @@ args = ap.parse_args()
 
 #--------------------------------------------------------------------------------------------------------------------------#
 # Geometry definitions.
+all_cells = []
 ## The core region.
+core_center = openmc.ZPlane(z0 = 0.0, boundary_type = 'reflective')
+core_top = openmc.ZPlane(z0 = geom.core_height)
 core_front = openmc.YPlane(y0 = pins_per_axis * geom.pitch, boundary_type = 'reflective')
 core_left = openmc.XPlane(x0 = -pins_per_axis * geom.pitch, boundary_type = 'reflective')
 core_right = openmc.XPlane(x0 = pins_per_axis * geom.pitch)
@@ -42,16 +45,10 @@ core_cells = [
   [asmb['MOX'],     asmb['UO2']]
 ]
 core_assembly = openmc.RectLattice(name = 'Core Assembly')
-core_assembly.pitch = (pins_per_axis * geom.pitch, pins_per_axis * geom.pitch)
-core_assembly.lower_left = (-pins_per_axis * geom.pitch, -pins_per_axis * geom.pitch)
-core_assembly.universes = core_cells
-
-core_z_planes = [ openmc.ZPlane(z0=z) for z in np.linspace(0.0, geom.core_height, args.n_axial + 1) ]
-core_z_planes[0].boundary_type = 'reflective'
-
-all_cells = []
-for layer_idx, planes in enumerate(zip(core_z_planes[:-1], core_z_planes[1:])):
-  all_cells.append(openmc.Cell(name = f'Core Assembly Cell {layer_idx}', region = core_bb_xy & +planes[0] & -planes[1], fill = core_assembly))
+core_assembly.pitch = (pins_per_axis * geom.pitch, pins_per_axis * geom.pitch, geom.core_height / args.n_axial)
+core_assembly.lower_left = (-pins_per_axis * geom.pitch, -pins_per_axis * geom.pitch, 0.0)
+core_assembly.universes = [ core_cells for i in range(args.n_axial)]
+all_cells.append(openmc.Cell(name = 'Core Assembly Cell', fill = core_assembly, region = core_bb_xy & +core_center & -core_top))
 
 ## The reflector region.
 refl_right = openmc.XPlane(x0 = pins_per_axis * geom.pitch + geom.reflector_t, boundary_type = 'vacuum')
@@ -63,25 +60,19 @@ upper_refl_assembly = openmc.RectLattice(name = 'Upper Reflector Assembly')
 upper_refl_assembly.pitch = (pins_per_axis * geom.pitch, pins_per_axis * geom.pitch)
 upper_refl_assembly.lower_left = (-pins_per_axis * geom.pitch, -pins_per_axis * geom.pitch)
 upper_refl_assembly.universes = [
-  [asmb['REF_ROD'], asmb['REF']],
-  [asmb['REF'],     asmb['REF']]
+  [asmb['REF'], asmb['REF']],
+  [asmb['REF'], asmb['REF']]
 ]
-all_cells.append(openmc.Cell(name = 'Upper Reflector Cell', region = +core_z_planes[-1] & -refl_top & core_bb_xy, fill = upper_refl_assembly))
+all_cells.append(openmc.Cell(name = 'Upper Reflector Cell', region = +core_top & -refl_top & core_bb_xy, fill = upper_refl_assembly))
 
 ### The remainder of the reflector.
-refl_region = -core_front & +refl_back & +core_left & -refl_right & -refl_top & +core_z_planes[0] & ~(core_bb_xy & +core_z_planes[0] & -refl_top)
-refl_cell = openmc.Cell(name = 'Water Reflector')
-refl_cell.region = refl_region
-refl_cell.fill = mats['H2O']
-all_cells.append(refl_cell)
-
-## The entire geometry.
-model_uni = openmc.Universe(cells = all_cells)
+refl_region = -core_front & +refl_back & +core_left & -refl_right & -refl_top & +core_center & ~(core_bb_xy & +core_center & -refl_top)
+all_cells.append(openmc.Cell(name = 'Water Reflector', fill = mats['H2O'], region = refl_region))
 #--------------------------------------------------------------------------------------------------------------------------#
 
 #--------------------------------------------------------------------------------------------------------------------------#
 # Setup the model.
-c5g7_model = openmc.Model(geometry = openmc.Geometry(model_uni), materials = openmc.Materials([mats['MOX_43'], mats['MOX_70'], mats['MOX_87'], mats['UO2'], mats['H2O'], mats['FISS'], mats['ZR_C'], mats['AL_C'], mats['BC4']]))
+c5g7_model = openmc.Model(geometry = openmc.Geometry(openmc.Universe(cells = all_cells)), materials = openmc.Materials([mats['MOX_43'], mats['MOX_70'], mats['MOX_87'], mats['UO2'], mats['H2O'], mats['FISS'], mats['ZR_C'], mats['AL_C'], mats['BC4']]))
 
 ## The simulation settings.
 c5g7_model.settings.source = [openmc.IndependentSource(space = openmc.stats.Box(lower_left = (-pins_per_axis * geom.pitch, -pins_per_axis * geom.pitch, 0.0),

--- a/models/lwr/multi_assembly/unrodded/make_openmc_model.py
+++ b/models/lwr/multi_assembly/unrodded/make_openmc_model.py
@@ -20,7 +20,7 @@ from argparse import ArgumentParser
 import openmc
 import openmc_common as geom
 from openmc_materials import MATERIALS as mats
-from openmc_assemblies import ASSEMBLIES as asmb
+from openmc_assemblies import ASSEMBLY_UNIVERSES as asmb
 from openmc_assemblies import pins_per_axis
 
 ap = ArgumentParser()
@@ -30,27 +30,25 @@ args = ap.parse_args()
 
 #--------------------------------------------------------------------------------------------------------------------------#
 # Geometry definitions.
+all_cells = []
 ## The core region.
+core_center = openmc.ZPlane(z0 = 0.0, boundary_type = 'reflective')
+core_top = openmc.ZPlane(z0 = geom.core_height)
 core_front = openmc.YPlane(y0 = pins_per_axis * geom.pitch, boundary_type = 'reflective')
 core_left = openmc.XPlane(x0 = -pins_per_axis * geom.pitch, boundary_type = 'reflective')
 core_right = openmc.XPlane(x0 = pins_per_axis * geom.pitch)
 core_back = openmc.YPlane(y0 = -pins_per_axis * geom.pitch)
 core_bb_xy = -core_front & +core_back & +core_left & -core_right
 
-core_assembly = openmc.RectLattice(name = 'Core Assembly')
-core_assembly.pitch = (pins_per_axis * geom.pitch, pins_per_axis * geom.pitch)
-core_assembly.lower_left = (-pins_per_axis * geom.pitch, -pins_per_axis * geom.pitch)
-core_assembly.universes = [
+core_cells = [
   [asmb['UO2'], asmb['MOX']],
-  [asmb['MOX'],     asmb['UO2']]
+  [asmb['MOX'], asmb['UO2']]
 ]
-
-core_z_planes = [ openmc.ZPlane(z0=z) for z in np.linspace(0.0, geom.core_height, args.n_axial + 1) ]
-core_z_planes[0].boundary_type = 'reflective'
-
-all_cells = []
-for layer_idx, planes in enumerate(zip(core_z_planes[:-1], core_z_planes[1:])):
-  all_cells.append(openmc.Cell(name = f'Core Assembly Cell {layer_idx}', region = core_bb_xy & +planes[0] & -planes[1], fill = core_assembly))
+core_assembly = openmc.RectLattice(name = 'Core Assembly')
+core_assembly.pitch = (pins_per_axis * geom.pitch, pins_per_axis * geom.pitch, geom.core_height / args.n_axial)
+core_assembly.lower_left = (-pins_per_axis * geom.pitch, -pins_per_axis * geom.pitch, 0.0)
+core_assembly.universes = [ core_cells for i in range(args.n_axial)]
+all_cells.append(openmc.Cell(name = 'Core Assembly Cell', fill = core_assembly, region = core_bb_xy & +core_center & -core_top))
 
 ## The reflector region.
 refl_right = openmc.XPlane(x0 = pins_per_axis * geom.pitch + geom.reflector_t, boundary_type = 'vacuum')
@@ -65,22 +63,16 @@ upper_refl_assembly.universes = [
   [asmb['REF'], asmb['REF']],
   [asmb['REF'], asmb['REF']]
 ]
-all_cells.append(openmc.Cell(name = 'Upper Reflector Cell', region = +core_z_planes[-1] & -refl_top & core_bb_xy, fill = upper_refl_assembly))
+all_cells.append(openmc.Cell(name = 'Upper Reflector Cell', region = +core_top & -refl_top & core_bb_xy, fill = upper_refl_assembly))
 
 ### The remainder of the reflector.
-refl_region = -core_front & +refl_back & +core_left & -refl_right & -refl_top & +core_z_planes[0] & ~(core_bb_xy & +core_z_planes[0] & -refl_top)
-refl_cell = openmc.Cell(name = 'Water Reflector')
-refl_cell.region = refl_region
-refl_cell.fill = mats['H2O']
-all_cells.append(refl_cell)
-
-## The entire geometry.
-model_uni = openmc.Universe(cells = all_cells)
+refl_region = -core_front & +refl_back & +core_left & -refl_right & -refl_top & +core_center & ~(core_bb_xy & +core_center & -refl_top)
+all_cells.append(openmc.Cell(name = 'Water Reflector', fill = mats['H2O'], region = refl_region))
 #--------------------------------------------------------------------------------------------------------------------------#
 
 #--------------------------------------------------------------------------------------------------------------------------#
 # Setup the model.
-c5g7_model = openmc.Model(geometry = openmc.Geometry(model_uni), materials = openmc.Materials([mats['MOX_43'], mats['MOX_70'], mats['MOX_87'], mats['UO2'], mats['H2O'], mats['FISS'], mats['ZR_C'], mats['AL_C']]))
+c5g7_model = openmc.Model(geometry = openmc.Geometry(openmc.Universe(cells = all_cells)), materials = openmc.Materials([mats['MOX_43'], mats['MOX_70'], mats['MOX_87'], mats['UO2'], mats['H2O'], mats['FISS'], mats['ZR_C'], mats['AL_C']]))
 
 ## The simulation settings.
 c5g7_model.settings.source = [openmc.IndependentSource(space = openmc.stats.Box(lower_left = (-pins_per_axis * geom.pitch, -pins_per_axis * geom.pitch, 0.0),

--- a/models/lwr/openmc_assemblies.py
+++ b/models/lwr/openmc_assemblies.py
@@ -20,6 +20,7 @@ from openmc_pincells import PINCELLS as pins
 ## The assemblies.
 pins_per_axis = 17.0
 ASSEMBLIES = {}
+ASSEMBLY_UNIVERSES = {}
 assembly_bb = openmc.model.RectangularPrism(width = pins_per_axis * geom.pitch, height = pins_per_axis * geom.pitch)
 
 ### Different assembly maps.
@@ -84,17 +85,18 @@ ASSEMBLY_MAPS = {
 }
 
 #### Replace all guide tubes with control rods for the rodded assembly.
-ASSEMBLY_MAPS['UO2_ROD'] = [ [ pin_type.replace('GTB', 'ROD') for pin_type in row] for row in ASSEMBLY_MAPS['UO2'] ]
+ASSEMBLY_MAPS['UO2_ROD'] = [ [ pin_type.replace('GTB', 'ROD') for pin_type in row ] for row in ASSEMBLY_MAPS['UO2'] ]
 
 #### Replace all guide tubes with control rods for the rodded reflector, other than the central guide tube.
-ASSEMBLY_MAPS['REF_ROD'] = [ [ pin_type.replace('GTB', 'ROD') for pin_type in row] for row in ASSEMBLY_MAPS['REF'] ]
+ASSEMBLY_MAPS['REF_ROD'] = [ [ pin_type.replace('GTB', 'ROD') for pin_type in row ] for row in ASSEMBLY_MAPS['REF'] ]
 ASSEMBLY_MAPS['REF_ROD'][8][8] = 'GTB'
 
-### The assembly universes.
+### The assembly cells.
 for name, map in ASSEMBLY_MAPS.items():
   assembly = openmc.RectLattice(name = name)
   assembly.pitch = (geom.pitch, geom.pitch)
   assembly.lower_left = (-pins_per_axis * geom.pitch / 2.0, -pins_per_axis * geom.pitch / 2.0)
   assembly.universes = [ [ pins[pin_type] for pin_type in row] for row in map ]
-  ASSEMBLIES[name] = openmc.Universe(cells = [openmc.Cell(name = name + ' Cell', region = -assembly_bb, fill = assembly)])
+  ASSEMBLIES[name] = openmc.Cell(name = name + ' Lattice Cell', region = -assembly_bb, fill = assembly)
+  ASSEMBLY_UNIVERSES[name] = openmc.Universe(name = name + ' Lattice Universe', cells=[ASSEMBLIES[name]])
 #--------------------------------------------------------------------------------------------------------------------------#

--- a/models/lwr/pincell/make_openmc_model.py
+++ b/models/lwr/pincell/make_openmc_model.py
@@ -30,8 +30,8 @@ args = ap.parse_args()
 #--------------------------------------------------------------------------------------------------------------------------#
 # Geometry definitions.
 pins.fuel_bb.boundary_type = 'reflective'
-fuel_center = openmc.ZPlane(z0=0.0, boundary_type='reflective')
-fuel_top = openmc.ZPlane(z0=geom.core_height)
+fuel_center = openmc.ZPlane(z0 = 0.0, boundary_type = 'reflective')
+fuel_top = openmc.ZPlane(z0 = geom.core_height)
 
 core_assembly = openmc.RectLattice(name = 'UO2 Pincell Lattice')
 core_assembly.pitch = (geom.pitch, geom.pitch, geom.core_height / args.n_axial)

--- a/models/lwr/pincell/mesh.i
+++ b/models/lwr/pincell/mesh.i
@@ -7,9 +7,6 @@
     heights = '${fparse core_height}'
     num_layers = '${AXIAL_DIVISIONS}'
     direction = '0.0 0.0 1.0'
-
-    bottom_boundary = '10001'
-    top_boundary = '10000'
   []
   [To_Origin]
     type = TransformGenerator


### PR DESCRIPTION
This quick PR changes the strategy used to handle axial discretization of the LWR OpenMC models from individual cells in the z-direction to 3D lattices.